### PR TITLE
Resolve Misplaced nikud under double-yud and double-vov digraphs (iss…

### DIFF
--- a/sources/FrankRuhlLibre.glyphs
+++ b/sources/FrankRuhlLibre.glyphs
@@ -45573,9 +45573,15 @@ width = 486.875;
 glyphname = "vavvav-hb";
 kernLeft = "vav-hb";
 kernRight = "vav-hb";
-lastChange = "2022-11-03 08:56:38 +0000";
+lastChange = "2023-03-26 15:01:50 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (285,0);
+}
+);
 layerId = "A270BFC0-E682-4EED-9FF7-BE35A5492496";
 shapes = (
 {
@@ -45589,6 +45595,12 @@ ref = "vav-hb";
 width = 502;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (374,0);
+}
+);
 layerId = "705D5379-5CC9-457D-BF30-EC6EB9252852";
 shapes = (
 {
@@ -45602,6 +45614,12 @@ ref = "vav-hb";
 width = 632;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (400,0);
+}
+);
 layerId = "C3F6A16D-5E1F-403C-905F-9502D4908E23";
 shapes = (
 {
@@ -45615,6 +45633,16 @@ ref = "vav-hb";
 width = 660;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (318,0);
+},
+{
+name = caret_1;
+pos = (275.5,0);
+}
+);
 layerId = "4CDCBC45-D394-4652-82F8-278E2907A602";
 shapes = (
 {
@@ -45628,6 +45656,7 @@ ref = "vav-hb";
 width = 551;
 }
 );
+subCategory = Other;
 unicode = 1520;
 },
 {
@@ -45701,9 +45730,15 @@ unicode = 1521;
 glyphname = "yodyod-hb";
 kernLeft = "yod-hb";
 kernRight = "yod-hb";
-lastChange = "2022-11-03 08:56:38 +0000";
+lastChange = "2023-03-26 18:15:34 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (256,0);
+}
+);
 layerId = "A270BFC0-E682-4EED-9FF7-BE35A5492496";
 shapes = (
 {
@@ -45717,6 +45752,12 @@ ref = "yod-hb";
 width = 516;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (295,0);
+}
+);
 layerId = "705D5379-5CC9-457D-BF30-EC6EB9252852";
 shapes = (
 {
@@ -45730,6 +45771,12 @@ ref = "yod-hb";
 width = 594;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (309,0);
+}
+);
 layerId = "C3F6A16D-5E1F-403C-905F-9502D4908E23";
 shapes = (
 {
@@ -45743,6 +45790,12 @@ ref = "yod-hb";
 width = 626;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (271,0);
+}
+);
 layerId = "4CDCBC45-D394-4652-82F8-278E2907A602";
 shapes = (
 {
@@ -45756,6 +45809,7 @@ ref = "yod-hb";
 width = 545;
 }
 );
+subCategory = Other;
 unicode = 1522;
 },
 {


### PR DESCRIPTION
…ue #16)

Change double-yud, aka U+05F0 HEBREW LIGATURE YIDDISH DOUBLE YOD (ײ), and double-vov, aka U+05F0 HEBREW LIGATURE YIDDISH DOUBLE VAV (װ), to correct horizontal placement under them of Hebrew diacritic ("nikud"), as follows:

(1) set subCategory explicitly to "Other", based on advice by @simoncozens in a Google Fonts issue here:
https://github.com/google/fonts/issues/6062

and

(2) add "bottom" anchors, positioned as follows:

  - Y pos is 0;

  - X pos is halfway between where the "bottom" anchor of each component character glyph G would be if laid side by side, computed as
```
      (X pos of "bottom" anchor of G
       + set width of G
       + X pos of "bottom" anchor of G)
      divided by 2
```
All changes are reflected in this new version of

  sources/FrankRuhlLibre.glyphs

Note: this was hand-tested by generating just a few font files and viewing in FontBook, but I leave it to upstream developers to perform the the full build based on this source change.